### PR TITLE
Request adding missing CIDR blocks via SQS instead of editing SSS in place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer "Red Hat OpenShift Dedicated SRE Team"
 RUN microdnf install -y python3 python3-pip
 RUN pip3 install openshift
 RUN pip3 install kubernetes
+RUN pip3 install boto3
 
 RUN mkdir /app
 WORKDIR /app

--- a/apischeme_SSS.py
+++ b/apischeme_SSS.py
@@ -69,7 +69,7 @@ def add_missing_ips(missing_ips):
     sqs = session.client('sqs')
     body = {
         'pr_type': 'create_cloud_ingress_operator_cidr_blocks_mr',
-        'cidr_blocks': missing_ips
+        'cidr_blocks': list(missing_ips)
     }
     sqs.send_message(
         QueueUrl=queue_url,
@@ -101,9 +101,9 @@ if not all_ips:
 ingress = resource.spec.managementAPIServerIngress
 
 ingress_ips = set(ingress.allowedCIDRBlocks)
-if ingress_ips == all_ips:
-    print("Same IPs, no-op\n%s" % all_ips)
+missing_ips = all_ips - ingress_ips
+if not missing_ips:
+    print("No IPs to add, no-op")
     sys.exit(0)
 
-missing_ips = [ip for ip in all_ips if ip not in ingress_ips]
 add_missing_ips(missing_ips)

--- a/deploy/20_private-cluster-rhapi-apischeme-updater-cronjob.CronJob.yaml
+++ b/deploy/20_private-cluster-rhapi-apischeme-updater-cronjob.CronJob.yaml
@@ -20,4 +20,25 @@ spec:
           containers:
           - name: private-cluster-rhapi-apischeme-updater
             image: "${REGISTRY_IMG}:${IMAGE_TAG}"
-            imagePullPolicy: Always            
+            imagePullPolicy: Always
+            env:
+            - name: aws_access_key_id
+              valueFrom:
+                secretKeyRef:
+                  name: pr-gateway
+                  key: aws_access_key_id
+            - name: aws_secret_access_key
+              valueFrom:
+                secretKeyRef:
+                  name: pr-gateway
+                  key: aws_access_key_id
+            - name: aws_region
+              valueFrom:
+                secretKeyRef:
+                  name: pr-gateway
+                  key: aws_region
+            - name: queue_url
+              valueFrom:
+                secretKeyRef:
+                  name: pr-gateway
+                  key: gitlab_pr_submitter_queue_url

--- a/hack/generated-templates/updater-template.yaml
+++ b/hack/generated-templates/updater-template.yaml
@@ -38,3 +38,24 @@ objects:
             - name: private-cluster-rhapi-apischeme-updater
               image: ${REGISTRY_IMG}:${IMAGE_TAG}
               imagePullPolicy: Always
+              env:
+              - name: aws_access_key_id
+                valueFrom:
+                  secretKeyRef:
+                    name: pr-gateway
+                    key: aws_access_key_id
+              - name: aws_secret_access_key
+                valueFrom:
+                  secretKeyRef:
+                    name: pr-gateway
+                    key: aws_access_key_id
+              - name: aws_region
+                valueFrom:
+                  secretKeyRef:
+                    name: pr-gateway
+                    key: aws_region
+              - name: queue_url
+                valueFrom:
+                  secretKeyRef:
+                    name: pr-gateway
+                    key: gitlab_pr_submitter_queue_url


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/OSD-4840

Depends on:
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8085
- https://github.com/app-sre/qontract-reconcile/pull/1009

This PR replaces the in-place edit of the cloud-ingress-operator SelectorSyncSet with sending a message to an SQS queue to request the addition of the missing entries. A message to this queue will result in a MR to app-interface that will be merged automatically. An example for such a merge request:
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8060

Once this PR is merged and proven in stage/int, we need to merge:
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8124

The SQS method will be replaced in the future with an API component that we are building as part of https://issues.redhat.com/browse/SDE-736.