### PR TITLE
Revert PR 18/19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL maintainer "Red Hat OpenShift Dedicated SRE Team"
 RUN microdnf install -y python3 python3-pip
 RUN pip3 install openshift
 RUN pip3 install kubernetes
-RUN pip3 install boto3
 
 RUN mkdir /app
 WORKDIR /app

--- a/apischeme_SSS.py
+++ b/apischeme_SSS.py
@@ -54,13 +54,8 @@ def get_bastion_ips(resource):
     return bastion_ips
 
 
-def _manage_ips(ips, operation):
-    """ Submit a request to add/remove entries to/from app-interface """
-    allowed_operations = ['add', 'remove']
-    if operation not in allowed_operations:
-        print("operation is not allowed")
-        sys.exit(1)
-
+def add_missing_ips(missing_ips):
+    """ Submit a request to add the missing entries to app-interface """
     aws_access_key_id = os.environ['aws_access_key_id']
     aws_secret_access_key = os.environ['aws_secret_access_key']
     aws_region = os.environ['aws_region']
@@ -74,23 +69,12 @@ def _manage_ips(ips, operation):
     sqs = session.client('sqs')
     body = {
         'pr_type': 'create_cloud_ingress_operator_cidr_blocks_mr',
-        'cidr_blocks': list(ips),
-        'operation': operation
+        'cidr_blocks': list(missing_ips)
     }
     sqs.send_message(
         QueueUrl=queue_url,
         MessageBody=json.dumps(body)
     )
-
-
-def add_ips(ips):
-    """ Submit a request to add entries to app-interface """
-    _manage_ips(ips, operation='add')
-
-
-def remove_ips(ips):
-    """ Submit a request to remove entries from app-interface """
-    _manage_ips(ips, operation='remove')
 
 
 sss = get_sss()
@@ -122,4 +106,4 @@ if not missing_ips:
     print("No IPs to add, no-op")
     sys.exit(0)
 
-add_ips(missing_ips)
+add_missing_ips(missing_ips)

--- a/apischeme_SSS.py
+++ b/apischeme_SSS.py
@@ -69,7 +69,7 @@ def add_missing_ips(missing_ips):
     sqs = session.client('sqs')
     body = {
         'pr_type': 'create_cloud_ingress_operator_cidr_blocks_mr',
-        'cidr_blocks': list(missing_ips)
+        'cidr_blocks': missing_ips
     }
     sqs.send_message(
         QueueUrl=queue_url,
@@ -101,9 +101,9 @@ if not all_ips:
 ingress = resource.spec.managementAPIServerIngress
 
 ingress_ips = set(ingress.allowedCIDRBlocks)
-missing_ips = all_ips - ingress_ips
-if not missing_ips:
-    print("No IPs to add, no-op")
+if ingress_ips == all_ips:
+    print("Same IPs, no-op\n%s" % all_ips)
     sys.exit(0)
 
+missing_ips = [ip for ip in all_ips if ip not in ingress_ips]
 add_missing_ips(missing_ips)

--- a/apischeme_SSS.py
+++ b/apischeme_SSS.py
@@ -8,7 +8,6 @@ import json
 
 from kubernetes import config
 from kubernetes.client import ApiClient
-from boto3 import Session
 
 from openshift.dynamic import DynamicClient
 
@@ -54,29 +53,6 @@ def get_bastion_ips(resource):
     return bastion_ips
 
 
-def add_missing_ips(missing_ips):
-    """ Submit a request to add the missing entries to app-interface """
-    aws_access_key_id = os.environ['aws_access_key_id']
-    aws_secret_access_key = os.environ['aws_secret_access_key']
-    aws_region = os.environ['aws_region']
-    queue_url = os.environ['queue_url']
-
-    session = Session(
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        region_name=aws_region,
-    )
-    sqs = session.client('sqs')
-    body = {
-        'pr_type': 'create_cloud_ingress_operator_cidr_blocks_mr',
-        'cidr_blocks': missing_ips
-    }
-    sqs.send_message(
-        QueueUrl=queue_url,
-        MessageBody=json.dumps(body)
-    )
-
-
 sss = get_sss()
 
 for resource in sss.spec.resources:
@@ -100,10 +76,20 @@ if not all_ips:
 
 ingress = resource.spec.managementAPIServerIngress
 
-ingress_ips = set(ingress.allowedCIDRBlocks)
-if ingress_ips == all_ips:
+if set(ingress.allowedCIDRBlocks) == all_ips:
     print("Same IPs, no-op\n%s" % all_ips)
     sys.exit(0)
 
-missing_ips = [ip for ip in all_ips if ip not in ingress_ips]
-add_missing_ips(missing_ips)
+# Overwrite the list of IPs
+ingress.allowedCIDRBlocks = list(all_ips)
+print("Applying IPs: %s" % ingress.allowedCIDRBlocks)
+
+# Tell cloud-ingress-operator it's okay to apply the CIDRs now.
+if not ingress.enabled:
+    print("Enabling ingress")
+    ingress.enabled = True  # As opposed to the string "true".
+
+sss_resources = dyn_client.resources.get(
+    api_version="hive.openshift.io/v1", kind="SelectorSyncSet"
+)
+dyn_client.apply(sss_resources, body=sss.to_dict())

--- a/deploy/20_private-cluster-rhapi-apischeme-updater-cronjob.CronJob.yaml
+++ b/deploy/20_private-cluster-rhapi-apischeme-updater-cronjob.CronJob.yaml
@@ -20,25 +20,4 @@ spec:
           containers:
           - name: private-cluster-rhapi-apischeme-updater
             image: "${REGISTRY_IMG}:${IMAGE_TAG}"
-            imagePullPolicy: Always
-            env:
-            - name: aws_access_key_id
-              valueFrom:
-                secretKeyRef:
-                  name: pr-gateway
-                  key: aws_access_key_id
-            - name: aws_secret_access_key
-              valueFrom:
-                secretKeyRef:
-                  name: pr-gateway
-                  key: aws_access_key_id
-            - name: aws_region
-              valueFrom:
-                secretKeyRef:
-                  name: pr-gateway
-                  key: aws_region
-            - name: queue_url
-              valueFrom:
-                secretKeyRef:
-                  name: pr-gateway
-                  key: gitlab_pr_submitter_queue_url
+            imagePullPolicy: Always            

--- a/deploy/20_private-cluster-rhapi-apischeme-updater-cronjob.CronJob.yaml
+++ b/deploy/20_private-cluster-rhapi-apischeme-updater-cronjob.CronJob.yaml
@@ -31,7 +31,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: pr-gateway
-                  key: aws_secret_access_key
+                  key: aws_access_key_id
             - name: aws_region
               valueFrom:
                 secretKeyRef:

--- a/hack/generated-templates/updater-template.yaml
+++ b/hack/generated-templates/updater-template.yaml
@@ -48,7 +48,7 @@ objects:
                 valueFrom:
                   secretKeyRef:
                     name: pr-gateway
-                    key: aws_secret_access_key
+                    key: aws_access_key_id
               - name: aws_region
                 valueFrom:
                   secretKeyRef:

--- a/hack/generated-templates/updater-template.yaml
+++ b/hack/generated-templates/updater-template.yaml
@@ -38,24 +38,3 @@ objects:
             - name: private-cluster-rhapi-apischeme-updater
               image: ${REGISTRY_IMG}:${IMAGE_TAG}
               imagePullPolicy: Always
-              env:
-              - name: aws_access_key_id
-                valueFrom:
-                  secretKeyRef:
-                    name: pr-gateway
-                    key: aws_access_key_id
-              - name: aws_secret_access_key
-                valueFrom:
-                  secretKeyRef:
-                    name: pr-gateway
-                    key: aws_access_key_id
-              - name: aws_region
-                valueFrom:
-                  secretKeyRef:
-                    name: pr-gateway
-                    key: aws_region
-              - name: queue_url
-                valueFrom:
-                  secretKeyRef:
-                    name: pr-gateway
-                    key: gitlab_pr_submitter_queue_url


### PR DESCRIPTION
Making [OHSS-1076](https://issues.redhat.com/browse/OHSS-1076) go away by

* Reverting pcrau PRs [#18](https://github.com/openshift/private-cluster-rhapi-apischeme-updater/pull/18) and [#19](https://github.com/openshift/private-cluster-rhapi-apischeme-updater/pull/19) (this commit)
* Reverting https://gitlab.cee.redhat.com/service/app-interface/-/commit/f40c3f77218a2fa7a3907313a1e3563c6070ff2f to allow the reverted pcrau to work again  ([elsewhere](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8438))
* Removing CIDRs added by pcrau at the behest of the above PRs ([elsewhere](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8438))

See also [OSD-4840](https://issues.redhat.com/browse/OSD-4840)